### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -10,8 +10,7 @@ while 1:
 
         nbytes = int(stdin.readline())
         if verbosity >= 2:
-            sys.stderr.write('server: assembling %r (%d bytes)\n'
-                             % (name, nbytes))
+            sys.stderr.write('server: assembling {0!r} ({1:d} bytes)\n'.format(name, nbytes))
         content = z.decompress(stdin.read(nbytes))
 
         module = imp.new_module(name)

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -14,7 +14,7 @@ from sshuttle.helpers import family_ip_tuple, log, Fatal
 def parse_subnet4(s):
     m = re.match(r'(\d+)(?:\.(\d+)\.(\d+)\.(\d+))?(?:/(\d+))?$', s)
     if not m:
-        raise Fatal('%r is not a valid IP subnet format' % s)
+        raise Fatal('{0!r} is not a valid IP subnet format'.format(s))
     (a, b, c, d, width) = m.groups()
     (a, b, c, d) = (int(a or 0), int(b or 0), int(c or 0), int(d or 0))
     if width is None:
@@ -22,24 +22,24 @@ def parse_subnet4(s):
     else:
         width = int(width)
     if a > 255 or b > 255 or c > 255 or d > 255:
-        raise Fatal('%d.%d.%d.%d has numbers > 255' % (a, b, c, d))
+        raise Fatal('{0:d}.{1:d}.{2:d}.{3:d} has numbers > 255'.format(a, b, c, d))
     if width > 32:
-        raise Fatal('*/%d is greater than the maximum of 32' % width)
-    return(socket.AF_INET, '%d.%d.%d.%d' % (a, b, c, d), width)
+        raise Fatal('*/{0:d} is greater than the maximum of 32'.format(width))
+    return(socket.AF_INET, '{0:d}.{1:d}.{2:d}.{3:d}'.format(a, b, c, d), width)
 
 
 # 1:2::3/64 or just 1:2::3
 def parse_subnet6(s):
     m = re.match(r'(?:([a-fA-F\d:]+))?(?:/(\d+))?$', s)
     if not m:
-        raise Fatal('%r is not a valid IP subnet format' % s)
+        raise Fatal('{0!r} is not a valid IP subnet format'.format(s))
     (net, width) = m.groups()
     if width is None:
         width = 128
     else:
         width = int(width)
     if width > 128:
-        raise Fatal('*/%d is greater than the maximum of 128' % width)
+        raise Fatal('*/{0:d} is greater than the maximum of 128'.format(width))
     return(socket.AF_INET6, net, width)
 
 
@@ -48,7 +48,7 @@ def parse_subnet_file(s):
     try:
         handle = open(s, 'r')
     except OSError:
-        raise Fatal('Unable to open subnet file: %s' % s)
+        raise Fatal('Unable to open subnet file: {0!s}'.format(s))
 
     raw_config_lines = handle.readlines()
     config_lines = []
@@ -82,17 +82,17 @@ def parse_ipport4(s):
     s = str(s)
     m = re.match(r'(?:(\d+)\.(\d+)\.(\d+)\.(\d+))?(?::)?(?:(\d+))?$', s)
     if not m:
-        raise Fatal('%r is not a valid IP:port format' % s)
+        raise Fatal('{0!r} is not a valid IP:port format'.format(s))
     (a, b, c, d, port) = m.groups()
     (a, b, c, d, port) = (int(a or 0), int(b or 0), int(c or 0), int(d or 0),
                           int(port or 0))
     if a > 255 or b > 255 or c > 255 or d > 255:
-        raise Fatal('%d.%d.%d.%d has numbers > 255' % (a, b, c, d))
+        raise Fatal('{0:d}.{1:d}.{2:d}.{3:d} has numbers > 255'.format(a, b, c, d))
     if port > 65535:
-        raise Fatal('*:%d is greater than the maximum of 65535' % port)
+        raise Fatal('*:{0:d} is greater than the maximum of 65535'.format(port))
     if a is None:
         a = b = c = d = 0
-    return ('%d.%d.%d.%d' % (a, b, c, d), port)
+    return ('{0:d}.{1:d}.{2:d}.{3:d}'.format(a, b, c, d), port)
 
 
 # [1:2::3]:456 or [1:2::3] or 456
@@ -100,7 +100,7 @@ def parse_ipport6(s):
     s = str(s)
     m = re.match(r'(?:\[([^]]*)])?(?::)?(?:(\d+))?$', s)
     if not m:
-        raise Fatal('%s is not a valid IP:port format' % s)
+        raise Fatal('{0!s} is not a valid IP:port format'.format(s))
     (ip, port) = m.groups()
     (ip, port) = (ip or '::', int(port or 0))
     return (ip, port)
@@ -193,7 +193,7 @@ def main():
             elif opt.method in ["auto", "nat", "tproxy", "pf"]:
                 method_name = opt.method
             else:
-                o.fatal("method_name %s not supported" % opt.method)
+                o.fatal("method_name {0!s} not supported".format(opt.method))
             if opt.listen:
                 ipport_v6 = None
                 ipport_v4 = None
@@ -228,11 +228,11 @@ def main():
             if return_code == 0:
                 log('Normal exit code, exiting...')
             else:
-                log('Abnormal exit code detected, failing...' % return_code)
+                log('Abnormal exit code detected, failing...'.format(*return_code))
             return return_code
 
     except Fatal as e:
-        log('fatal: %s\n' % e)
+        log('fatal: {0!s}\n'.format(e))
         return 99
     except KeyboardInterrupt:
         log('\n')

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -7,7 +7,7 @@ def nonfatal(func, *args):
     try:
         func(*args)
     except Fatal as e:
-        log('error: %s\n' % e)
+        log('error: {0!s}\n'.format(e))
 
 
 def ipt_chain_exists(family, table, name):
@@ -16,15 +16,15 @@ def ipt_chain_exists(family, table, name):
     elif family == socket.AF_INET:
         cmd = 'iptables'
     else:
-        raise Exception('Unsupported family "%s"' % family_to_string(family))
+        raise Exception('Unsupported family "{0!s}"'.format(family_to_string(family)))
     argv = [cmd, '-t', table, '-nL']
     p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE)
     for line in p.stdout:
-        if line.startswith(b'Chain %s ' % name.encode("ASCII")):
+        if line.startswith(b'Chain {0!s} '.format(name.encode("ASCII"))):
             return True
     rv = p.wait()
     if rv:
-        raise Fatal('%r returned %d' % (argv, rv))
+        raise Fatal('{0!r} returned {1:d}'.format(argv, rv))
 
 
 def ipt(family, table, *args):
@@ -33,11 +33,11 @@ def ipt(family, table, *args):
     elif family == socket.AF_INET:
         argv = ['iptables', '-t', table] + list(args)
     else:
-        raise Exception('Unsupported family "%s"' % family_to_string(family))
-    debug1('>> %s\n' % ' '.join(argv))
+        raise Exception('Unsupported family "{0!s}"'.format(family_to_string(family)))
+    debug1('>> {0!s}\n'.format(' '.join(argv)))
     rv = ssubprocess.call(argv)
     if rv:
-        raise Fatal('%r returned %d' % (argv, rv))
+        raise Fatal('{0!r} returned {1:d}'.format(argv, rv))
 
 
 _no_ttl_module = False

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -15,7 +15,7 @@ def original_dst(sock):
         (proto, port, a, b, c, d) = struct.unpack('!HHBBBB', sockaddr_in[:8])
         # FIXME: decoding is IPv4 only.
         assert(socket.htons(proto) == socket.AF_INET)
-        ip = '%d.%d.%d.%d' % (a, b, c, d)
+        ip = '{0:d}.{1:d}.{2:d}.{3:d}'.format(a, b, c, d)
         return (ip, port)
     except socket.error as e:
         if e.args[0] == errno.ENOPROTOOPT:
@@ -52,8 +52,7 @@ class BaseMethod(object):
 
     def send_udp(self, sock, srcip, dstip, data):
         if srcip is not None:
-            Fatal("Method %s send_udp does not support setting srcip to %r"
-                  % (self.name, srcip))
+            Fatal("Method {0!s} send_udp does not support setting srcip to {1!r}".format(self.name, srcip))
         sock.sendto(data, dstip)
 
     def setup_tcp_listener(self, tcp_listener):
@@ -67,8 +66,7 @@ class BaseMethod(object):
         for key in ["udp", "dns", "ipv6"]:
             if getattr(features, key) and not getattr(avail, key):
                 raise Fatal(
-                    "Feature %s not supported with method %s.\n" %
-                    (key, self.name))
+                    "Feature {0!s} not supported with method {1!s}.\n".format(key, self.name))
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp):
         raise NotImplementedError()
@@ -83,13 +81,13 @@ class BaseMethod(object):
 def _program_exists(name):
     paths = (os.getenv('PATH') or os.defpath).split(os.pathsep)
     for p in paths:
-        fn = '%s/%s' % (p, name)
+        fn = '{0!s}/{1!s}'.format(p, name)
         if os.path.exists(fn):
             return not os.path.isdir(fn) and os.access(fn, os.X_OK)
 
 
 def get_method(method_name):
-    module = importlib.import_module("sshuttle.methods.%s" % method_name)
+    module = importlib.import_module("sshuttle.methods.{0!s}".format(method_name))
     return module.Method(method_name)
 
 

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -15,8 +15,7 @@ class Method(BaseMethod):
         # only ipv4 supported with NAT
         if family != socket.AF_INET:
             raise Exception(
-                'Address family "%s" unsupported by nat method_name'
-                % family_to_string(family))
+                'Address family "{0!s}" unsupported by nat method_name'.format(family_to_string(family)))
         if udp:
             raise Exception("UDP not supported by nat method_name")
 
@@ -28,7 +27,7 @@ class Method(BaseMethod):
         def _ipt_ttl(*args):
             return ipt_ttl(family, table, *args)
 
-        chain = 'sshuttle-%s' % port
+        chain = 'sshuttle-{0!s}'.format(port)
 
         # basic cleanup/setup of chains
         self.restore_firewall(port, family, udp)
@@ -47,17 +46,17 @@ class Method(BaseMethod):
                 in sorted(subnets, key=lambda s: s[1], reverse=True):
             if sexclude:
                 _ipt('-A', chain, '-j', 'RETURN',
-                     '--dest', '%s/%s' % (snet, swidth),
+                     '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                      '-p', 'tcp')
             else:
                 _ipt_ttl('-A', chain, '-j', 'REDIRECT',
-                         '--dest', '%s/%s' % (snet, swidth),
+                         '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                          '-p', 'tcp',
                          '--to-ports', str(port))
 
         for f, ip in [i for i in nslist if i[0] == family]:
             _ipt_ttl('-A', chain, '-j', 'REDIRECT',
-                     '--dest', '%s/32' % ip,
+                     '--dest', '{0!s}/32'.format(ip),
                      '-p', 'udp',
                      '--dport', '53',
                      '--to-ports', str(dnsport))
@@ -66,8 +65,7 @@ class Method(BaseMethod):
         # only ipv4 supported with NAT
         if family != socket.AF_INET:
             raise Exception(
-                'Address family "%s" unsupported by nat method_name'
-                % family_to_string(family))
+                'Address family "{0!s}" unsupported by nat method_name'.format(family_to_string(family)))
         if udp:
             raise Exception("UDP not supported by nat method_name")
 
@@ -79,7 +77,7 @@ class Method(BaseMethod):
         def _ipt_ttl(*args):
             return ipt_ttl(family, table, *args)
 
-        chain = 'sshuttle-%s' % port
+        chain = 'sshuttle-{0!s}'.format(port)
 
         # basic cleanup/setup of chains
         if ipt_chain_exists(family, table, chain):

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -44,7 +44,7 @@ if recvmsg == "python":
                     start = 4
                     length = 4
                 else:
-                    raise Fatal("Unsupported socket type '%s'" % family)
+                    raise Fatal("Unsupported socket type '{0!s}'".format(family))
                 ip = socket.inet_ntop(family, cmsg_data[start:start + length])
                 dstip = (ip, port)
                 break
@@ -55,7 +55,7 @@ if recvmsg == "python":
                     start = 8
                     length = 16
                 else:
-                    raise Fatal("Unsupported socket type '%s'" % family)
+                    raise Fatal("Unsupported socket type '{0!s}'".format(family))
                 ip = socket.inet_ntop(family, cmsg_data[start:start + length])
                 dstip = (ip, port)
                 break
@@ -75,7 +75,7 @@ elif recvmsg == "socket_ext":
                     start = 4
                     length = 4
                 else:
-                    raise Fatal("Unsupported socket type '%s'" % family)
+                    raise Fatal("Unsupported socket type '{0!s}'".format(family))
                 ip = socket.inet_ntop(
                     family, a.cmsg_data[start:start + length])
                 dstip = (ip, port)
@@ -87,7 +87,7 @@ elif recvmsg == "socket_ext":
                     start = 8
                     length = 16
                 else:
-                    raise Fatal("Unsupported socket type '%s'" % family)
+                    raise Fatal("Unsupported socket type '{0!s}'".format(family))
                 ip = socket.inet_ntop(
                     family, a.cmsg_data[start:start + length])
                 dstip = (ip, port)
@@ -152,8 +152,7 @@ class Method(BaseMethod):
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
-                'Address family "%s" unsupported by tproxy method'
-                % family_to_string(family))
+                'Address family "{0!s}" unsupported by tproxy method'.format(family_to_string(family)))
 
         table = "mangle"
 
@@ -163,9 +162,9 @@ class Method(BaseMethod):
         def _ipt_ttl(*args):
             return ipt_ttl(family, table, *args)
 
-        mark_chain = 'sshuttle-m-%s' % port
-        tproxy_chain = 'sshuttle-t-%s' % port
-        divert_chain = 'sshuttle-d-%s' % port
+        mark_chain = 'sshuttle-m-{0!s}'.format(port)
+        tproxy_chain = 'sshuttle-t-{0!s}'.format(port)
+        divert_chain = 'sshuttle-d-{0!s}'.format(port)
 
         # basic cleanup/setup of chains
         self.restore_firewall(port, family, udp)
@@ -189,11 +188,11 @@ class Method(BaseMethod):
 
         for f, ip in [i for i in nslist if i[0] == family]:
             _ipt('-A', mark_chain, '-j', 'MARK', '--set-mark', '1',
-                 '--dest', '%s/32' % ip,
+                 '--dest', '{0!s}/32'.format(ip),
                  '-m', 'udp', '-p', 'udp', '--dport', '53')
             _ipt('-A', tproxy_chain, '-j', 'TPROXY',
                  '--tproxy-mark', '0x1/0x1',
-                 '--dest', '%s/32' % ip,
+                 '--dest', '{0!s}/32'.format(ip),
                  '-m', 'udp', '-p', 'udp', '--dport', '53',
                  '--on-port', str(dnsport))
 
@@ -201,44 +200,43 @@ class Method(BaseMethod):
                 in sorted(subnets, key=lambda s: s[1], reverse=True):
             if sexclude:
                 _ipt('-A', mark_chain, '-j', 'RETURN',
-                     '--dest', '%s/%s' % (snet, swidth),
+                     '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                      '-m', 'tcp', '-p', 'tcp')
                 _ipt('-A', tproxy_chain, '-j', 'RETURN',
-                     '--dest', '%s/%s' % (snet, swidth),
+                     '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                      '-m', 'tcp', '-p', 'tcp')
             else:
                 _ipt('-A', mark_chain, '-j', 'MARK', '--set-mark', '1',
-                     '--dest', '%s/%s' % (snet, swidth),
+                     '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                      '-m', 'tcp', '-p', 'tcp')
                 _ipt('-A', tproxy_chain, '-j', 'TPROXY',
                      '--tproxy-mark', '0x1/0x1',
-                     '--dest', '%s/%s' % (snet, swidth),
+                     '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                      '-m', 'tcp', '-p', 'tcp',
                      '--on-port', str(port))
 
             if udp:
                 if sexclude:
                     _ipt('-A', mark_chain, '-j', 'RETURN',
-                         '--dest', '%s/%s' % (snet, swidth),
+                         '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                          '-m', 'udp', '-p', 'udp')
                     _ipt('-A', tproxy_chain, '-j', 'RETURN',
-                         '--dest', '%s/%s' % (snet, swidth),
+                         '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                          '-m', 'udp', '-p', 'udp')
                 else:
                     _ipt('-A', mark_chain, '-j', 'MARK', '--set-mark', '1',
-                         '--dest', '%s/%s' % (snet, swidth),
+                         '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                          '-m', 'udp', '-p', 'udp')
                     _ipt('-A', tproxy_chain, '-j', 'TPROXY',
                          '--tproxy-mark', '0x1/0x1',
-                         '--dest', '%s/%s' % (snet, swidth),
+                         '--dest', '{0!s}/{1!s}'.format(snet, swidth),
                          '-m', 'udp', '-p', 'udp',
                          '--on-port', str(port))
 
     def restore_firewall(self, port, family, udp):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
-                'Address family "%s" unsupported by tproxy method'
-                % family_to_string(family))
+                'Address family "{0!s}" unsupported by tproxy method'.format(family_to_string(family)))
 
         table = "mangle"
 
@@ -248,9 +246,9 @@ class Method(BaseMethod):
         def _ipt_ttl(*args):
             return ipt_ttl(family, table, *args)
 
-        mark_chain = 'sshuttle-m-%s' % port
-        tproxy_chain = 'sshuttle-t-%s' % port
-        divert_chain = 'sshuttle-d-%s' % port
+        mark_chain = 'sshuttle-m-{0!s}'.format(port)
+        tproxy_chain = 'sshuttle-t-{0!s}'.format(port)
+        divert_chain = 'sshuttle-d-{0!s}'.format(port)
 
         # basic cleanup/setup of chains
         if ipt_chain_exists(family, table, mark_chain):

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -110,14 +110,14 @@ class Options:
             l = lines.pop()
             if l == '--':
                 break
-            out.append('%s: %s\n' % (first_syn and 'usage' or '   or', l))
+            out.append('{0!s}: {1!s}\n'.format(first_syn and 'usage' or '   or', l))
             first_syn = False
         out.append('\n')
         last_was_option = False
         while lines:
             l = lines.pop()
             if l.startswith(' '):
-                out.append('%s%s\n' % (last_was_option and '\n' or '',
+                out.append('{0!s}{1!s}\n'.format(last_was_option and '\n' or '',
                                        l.lstrip()))
                 last_was_option = False
             elif l:
@@ -152,7 +152,7 @@ class Options:
                 flags_nice = ', '.join(flagl_nice)
                 if has_parm:
                     flags_nice += ' ...'
-                prefix = '    %-20s  ' % flags_nice
+                prefix = '    {0:<20!s}  '.format(flags_nice)
                 argtext = '\n'.join(textwrap.wrap(extra, width=_tty_width(),
                                                   initial_indent=prefix,
                                                   subsequent_indent=' ' * 28))
@@ -172,7 +172,7 @@ class Options:
 
     def fatal(self, s):
         """Print an error message to stderr and abort with usage string."""
-        msg = 'error: %s\n' % s
+        msg = 'error: {0!s}\n'.format(s)
         sys.stderr.write(msg)
         return self.usage(msg)
 

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -49,7 +49,7 @@ def empackage(z, name, data=None):
     content = z.compress(data)
     content += z.flush(zlib.Z_SYNC_FLUSH)
 
-    return b'%s\n%d\n%s' % (name.encode("ASCII"), len(content), content)
+    return b'{0!s}\n{1:d}\n{2!s}'.format(name.encode("ASCII"), len(content), content)
 
 
 def connect(ssh_cmd, rhostport, python, stderr, options):
@@ -78,7 +78,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
 
     z = zlib.compressobj(1)
     content = readfile('sshuttle.assembler')
-    optdata = ''.join("%s=%r\n" % (k, v) for (k, v) in list(options.items()))
+    optdata = ''.join("{0!s}={1!r}\n".format(k, v) for (k, v) in list(options.items()))
     optdata = optdata.encode("UTF8")
     content2 = (empackage(z, 'sshuttle') +
                 empackage(z, 'sshuttle.cmdline_options', optdata) +
@@ -90,10 +90,10 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
 
     pyscript = r"""
                 import sys;
-                verbosity=%d;
+                verbosity={0:d};
                 stdin=getattr(sys.stdin,"buffer",sys.stdin);
-                exec(compile(stdin.read(%d), "assembler.py", "exec"))
-                """ % (helpers.verbose or 0, len(content))
+                exec(compile(stdin.read({1:d}), "assembler.py", "exec"))
+                """.format(helpers.verbose or 0, len(content))
     pyscript = re.sub(r'\s+', ' ', pyscript.strip())
 
     if not rhost:
@@ -106,7 +106,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
         else:
             sshl = ['ssh']
         if python:
-            pycmd = "'%s' -c '%s'" % (python, pyscript)
+            pycmd = "'{0!s}' -c '{1!s}'".format(python, pyscript)
         else:
             pycmd = ("P=python3.5; $P -V 2>/dev/null || P=python; "
                      "exec \"$P\" -c '%s'") % pyscript
@@ -120,7 +120,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
         s2.close()
     s1a, s1b = os.dup(s1.fileno()), os.dup(s1.fileno())
     s1.close()
-    debug2('executing: %r\n' % argv)
+    debug2('executing: {0!r}\n'.format(argv))
     p = ssubprocess.Popen(argv, stdin=s1a, stdout=s1b, preexec_fn=setup,
                           close_fds=True, stderr=stderr)
     os.close(s1a)

--- a/sshuttle/stresstest.py
+++ b/sshuttle/stresstest.py
@@ -25,10 +25,10 @@ while 1:
         count += 1
         if count >= 16384:
             count = 1
-        print('cli CREATING %d' % count)
+        print('cli CREATING {0:d}'.format(count))
         b = struct.pack('I', count) + 'x' * count
         remain[c] = count
-        print('cli  >> %r' % len(b))
+        print('cli  >> {0!r}'.format(len(b)))
         c.send(b)
         c.shutdown(socket.SHUT_WR)
         clients.append(c)
@@ -36,7 +36,7 @@ while 1:
         time.sleep(0.1)
     else:
         r = [listener] + servers + clients
-    print('select(%d)' % len(r))
+    print('select({0:d})'.format(len(r)))
     r, w, x = select.select(r, [], [], 5)
     assert(r)
     for i in r:
@@ -45,7 +45,7 @@ while 1:
             servers.append(s)
         elif i in servers:
             b = i.recv(4096)
-            print('srv <<  %r' % len(b))
+            print('srv <<  {0!r}'.format(len(b)))
             if i not in remain:
                 assert(len(b) >= 4)
                 want = struct.unpack('I', b[:4])[0]
@@ -54,34 +54,34 @@ while 1:
             else:
                 want = remain[i]
             if want < len(b):
-                print('weird wanted %d bytes, got %d: %r' % (want, len(b), b))
+                print('weird wanted {0:d} bytes, got {1:d}: {2!r}'.format(want, len(b), b))
                 assert(want >= len(b))
             want -= len(b)
             remain[i] = want
             if not b:  # EOF
                 if want:
-                    print('weird: eof but wanted %d more' % want)
+                    print('weird: eof but wanted {0:d} more'.format(want))
                     assert(want == 0)
                 i.close()
                 servers.remove(i)
                 del remain[i]
             else:
-                print('srv  >> %r' % len(b))
+                print('srv  >> {0!r}'.format(len(b)))
                 i.send('y' * len(b))
                 if not want:
                     i.shutdown(socket.SHUT_WR)
         elif i in clients:
             b = i.recv(4096)
-            print('cli <<  %r' % len(b))
+            print('cli <<  {0!r}'.format(len(b)))
             want = remain[i]
             if want < len(b):
-                print('weird wanted %d bytes, got %d: %r' % (want, len(b), b))
+                print('weird wanted {0:d} bytes, got {1:d}: {2!r}'.format(want, len(b), b))
                 assert(want >= len(b))
             want -= len(b)
             remain[i] = want
             if not b:  # EOF
                 if want:
-                    print('weird: eof but wanted %d more' % want)
+                    print('weird: eof but wanted {0:d} more'.format(want))
                     assert(want == 0)
                 i.close()
                 clients.remove(i)

--- a/sshuttle/tests/test_methods_pf.py
+++ b/sshuttle/tests/test_methods_pf.py
@@ -93,7 +93,7 @@ def test_firewall_command_darwin(mock_pf_get_dev, mock_ioctl, mock_stdout):
     method = get_method('pf')
     assert not method.firewall_command("somthing")
 
-    command = "QUERY_PF_NAT %d,%d,%s,%d,%s,%d\n" % (
+    command = "QUERY_PF_NAT {0:d},{1:d},{2!s},{3:d},{4!s},{5:d}\n".format(
         socket.AF_INET, socket.IPPROTO_TCP,
         "127.0.0.1", 1025, "127.0.0.2", 1024)
     assert method.firewall_command(command)
@@ -116,7 +116,7 @@ def test_firewall_command_freebsd(mock_pf_get_dev, mock_ioctl, mock_stdout):
     method = get_method('pf')
     assert not method.firewall_command("somthing")
 
-    command = "QUERY_PF_NAT %d,%d,%s,%d,%s,%d\n" % (
+    command = "QUERY_PF_NAT {0:d},{1:d},{2!s},{3:d},{4!s},{5:d}\n".format(
         socket.AF_INET, socket.IPPROTO_TCP,
         "127.0.0.1", 1025, "127.0.0.2", 1024)
     assert method.firewall_command(command)
@@ -139,7 +139,7 @@ def test_firewall_command_openbsd(mock_pf_get_dev, mock_ioctl, mock_stdout):
     method = get_method('pf')
     assert not method.firewall_command("somthing")
 
-    command = "QUERY_PF_NAT %d,%d,%s,%d,%s,%d\n" % (
+    command = "QUERY_PF_NAT {0:d},{1:d},{2!s},{3:d},{4!s},{5:d}\n".format(
         socket.AF_INET, socket.IPPROTO_TCP,
         "127.0.0.1", 1025, "127.0.0.2", 1024)
     assert method.firewall_command(command)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:sshuttle?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:sshuttle?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
